### PR TITLE
Fix TGAS extraction path in running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The TGAS catalog files (Gaia data) are **not** in the repository, so if you want
 from source you either need to choose `HYG` in the Data tab of the configuration dialog or download
 the `tar` file [here (version 1.0.3 or older)](http://wwwstaff.ari.uni-heidelberg.de/gaiasandbox/files/20161206_tgas_gaiasky_1.0.3.tar.gz) 
 or [here (version 1.0.4 or newer)](http://wwwstaff.ari.uni-heidelberg.de/gaiasandbox/files/20161206_tgas_gaiasky_1.0.4.tar.gz) and
-extract it into the folder `gaiasky/android/assets/octree`.
+extract it into the folder `gaiasky/android/assets/data/octree`.
 
 And then, you are ready to rumble:
 ```


### PR DESCRIPTION
From my tests and according to the defaults, the tgas files should be extracted in the additional subdirectory "data".