### PR TITLE
Fix README rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 --------------------------
 [![Circle CI](https://circleci.com/gh/langurmonkey/gaiasky/tree/master.svg?style=svg)](https://circleci.com/gh/langurmonkey/gaiasky/tree/master)
 
-
 [**Gaia Sky**](https://zah.uni-heidelberg.de/gaia/outreach/gaiasky) is a real-time, 3D, astronomy visualisation software that
 runs on Windows, Linux and MacOS. It is developed in the framework of
 [ESA](http://www.esa.int/ESA)'s [Gaia mission](http://sci.esa.int/gaia) to chart about 1 billion stars of our Galaxy.
 To get the latest up-to-date and most complete information,
-
 
 *  Visit our [**home page**](https://zah.uni-heidelberg.de/gaia/outreach/gaiasky)
 *  Read the [**Documentation**](http://gaia-sky.readthedocs.io)
@@ -23,13 +21,9 @@ This file contains the following sections:
 5. Contact information
 6. Credits and acknowledgements
 
+##  1. Installation instructions and requirements
 
-
-######################################################
-##  1. Installation instructions and requirements    #
-######################################################
-
-###1.1 Requirements
+### 1.1 Requirements
 
 | **Operating system**  | Windows 7+ / MacOS X / Linux |
 | :---: | :--- |
@@ -39,16 +33,13 @@ This file contains the following sections:
 | **Hard drive**  | 230 MB of free disk space  |
 | **Java**  | On Linux, you need the Java Runtime Environment 7+ installed (openJRE is fine) |
 
-
-
-
-###1.2 Installation and uninstallation
+### 1.2 Installation and uninstallation
 
 Depending on your system and your personal preferences the installation
 procedure may vary. Below is a description of the various installation methods
 available. You can download the packages [here](https://zah.uni-heidelberg.de/?id=660).
 
-####1.2.1 Windows
+#### 1.2.1 Windows
 
 Two windows installers are available for 32 and 64-bit systems [here](https://zah.uni-heidelberg.de/?id=660).
 
@@ -64,12 +55,12 @@ directory where the application is to be installed.
 In order to **uninstall** the application you can use the Windows Control Panel or
 you can use the provided uninstaller in the Gaia Sky folder.
 
-####1.2.2 Linux
+#### 1.2.2 Linux
 
 We provide 4 packages for linux systems. `deb`, `rpm`, an `aur` package and a linux installer. You can get them [here](https://zah.uni-heidelberg.de/?id=660).
 The `aur` package can be installed using any `AUR` helper.
 
-#####1.2.2.1 DEB
+##### 1.2.2.1 DEB
 
 This is the package for Debian-based distros (Debian, Ubuntu, Mint, SteamOS, etc.).
 Download the `gaiasandbox_linux_<version>.deb` file and run the
@@ -88,7 +79,7 @@ In order to **uninstall**, just type:
 ```
 sudo apt-get remove gaiasky
 ```
-#####1.2.2.2 AUR
+##### 1.2.2.2 AUR
 
 We also provide an [AUR package](https://aur.archlinux.org/packages/gaiasky/) called `gaiasky`. You can install it easily with any tool capable of accessing `AUR`, for example `yaourt`.
 
@@ -96,9 +87,7 @@ We also provide an [AUR package](https://aur.archlinux.org/packages/gaiasky/) ca
 yaourt -S gaiasky
 ```
 
-
-
-#####1.2.2.3 RPM
+##### 1.2.2.3 RPM
 
 This is the package for RPM-based distributions (Red Hat, Fedora, Mandriva, SUSE, CentOS, etc.)
 Download the `gaiasky_linux_<version>.rpm` file and run the
@@ -118,7 +107,7 @@ In order to **uninstall**, just type:
 sudo yum remove gaiasky-x86
 ```
 
-#####1.2.2.4 Linux installer
+##### 1.2.2.4 Linux installer
 
 We also provide a Linux installer ([here](https://zah.uni-heidelberg.de/?id=660)) which will trigger a graphical interface
 where you can choose the installation location and some other settings.
@@ -134,42 +123,40 @@ Follow the on-screen instructions to proceed with the installation.
 In order to **uninstall**, just run the `uninstall` file in the
 installation folder.
 
-####1.2.3 OS X - Mac
+#### 1.2.3 OS X - Mac
 
 For OS X we provide a `gaiasky_macos_<version>.dmg` file
 which is installed by unpacking into the Applications folder. Get it [here](https://zah.uni-heidelberg.de/?id=660). Once unpacked, the installer will come up, just follow its instructions.
 
-####1.2.4 Compressed (TGZ) package
+#### 1.2.4 Compressed (TGZ) package
 
 A `gaiasky-<version>.tgz` package file is also provided. It will work
 in all systems but you need to unpack it yourself and create the desired
 shortcuts.
+
 In **Windows**, use an archiver software (7zip, iZArc, etc.) to unpack it.
 
 In **Linux** and **OS X**, you can use:
+
 ```
 tar -zxvf gaiasky-<version>.tgz
 ```
 
+##  2. Running instructions
 
-
-
-######################################################
-##  2. Running instructions                          #
-######################################################
-
-###2.1 Running Gaia Sky
+### 2.1 Running Gaia Sky
 
 In order to run the program just click on the shortcut
 provided in your operating system.
 
-###2.2 Running from code
+### 2.2 Running from code
 
 First, clone the [GitHub](https://github.com/langurmonkey/gaiasky) repository:
 
 ```
 git clone https://github.com/langurmonkey/gaiasky.git
 ```
+
 Make sure you have at least `JDK7` installed.
 
 The TGAS catalog files (Gaia data) are **not** in the repository, so if you want to use TGAS when running
@@ -179,34 +166,25 @@ or [here (version 1.0.4 or newer)](http://wwwstaff.ari.uni-heidelberg.de/gaiasan
 extract it into the folder `gaiasky/android/assets/data/octree`.
 
 And then, you are ready to rumble:
+
 ```
 cd gaiasky
 gradlew desktop:run
 ```
 Et voilà! Gaia Sky is running on your machine.
 
-
-######################################################
-##  3. Documentation and help                        #
-######################################################
+##  3. Documentation and help
 
 The most up-to-date documentation of Gaia Sky is always in [gaia-sky.readthedocs.io](http://gaia-sky.readthedocs.io).
 
-
-######################################################
-##  4. Copyright and licensing information           #
-######################################################
+##  4. Copyright and licensing information
 
 This software is published and distributed under the GPLv3
 (GNU General Public License v3) license. You can find the full license
 text here https://github.com/langurmonkey/gaiasky/blob/master/LICENSE.md
 or visiting https://www.gnu.org/licenses/gpl.html
 
-
-
-######################################################
-##  5. Contact information                           #
-######################################################
+##  5. Contact information
 
 The main webpage of the project is
 http://www.zah.uni-heidelberg.de/gaia/outreach/gaiasky. There you can find


### PR DESCRIPTION
Github has moved from Sundown to cmark, as per https://githubengineering.com/a-formal-spec-for-github-markdown/ . This broke a lot of stylization in this repo's README.

My PR fixes the issues by putting a space between the text and headers as well as unfortunately removing the surrounding hashes (which cannot be done with cmark)