### PR TITLE
REST server static files use assets.location

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,7 +57,6 @@ task run(dependsOn: jar, type: JavaExec, description: "Runs the desktop project 
     main = project.mainClassName
     systemProperties['properties.file'] = ''
     systemProperties['assets.location'] = '../assets/'
-    systemProperties['rest-static.location'] = '../assets/rest-static/'
     systemProperties['org.slf4j.simpleLogger.defaultLogLevel'] = 'warn'  // logging levels (e.g. REST server warn, info, debug)
     systemProperties['org.slf4j.simpleLogger.showThreadName'] = 'false'
 

--- a/core/exe/gaiasky
+++ b/core/exe/gaiasky
@@ -56,9 +56,6 @@ OPTS="$OPTS -XX:+UseG1GC"
 # Assets location
 OPTS="$OPTS -Dassets.location=\"$GSDIR/\""
 
-# REST server static files location
-OPTS="$OPTS -Drest-static.location=\"$GSDIR/rest-static/\""
-
 # SimpleLogger defaults 
 OPTS="$OPTS -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dorg.slf4j.simpleLogger.showThreadName=false"
 

--- a/core/src/gaia/cu9/ari/gaiaorbit/rest/RESTServer.java
+++ b/core/src/gaia/cu9/ari/gaiaorbit/rest/RESTServer.java
@@ -116,9 +116,9 @@ public class RESTServer {
 	private static Integer port = -1;
 
 	/**
-	 * REST server static files location. Defined by a system property.
+	 * REST server static files location.
 	 */
-	private static String rest_static_location = System.getProperty("rest-static.location");
+	private static String rest_static_location = System.getProperty("assets.location") + "rest-static";
 
 	/* Methods: */
 
@@ -494,18 +494,18 @@ public class RESTServer {
 			System.out.println("Error: invalid port. REST API inactive.");
 			return;
 		}
-		if (rest_static_location == null) {
-			System.out.println("Error: rest-static.location not set. REST API inactive.");
-			return;
-		}
 
 		try {
 			Logger.warn("Starting REST API server on http://localhost:{}", port);
 			port(port);
 			Logger.info("Setting routes");
 
-			/* Static file location */
-			/* (add static HTML files with API use examples) */
+			/*
+			 * Static file location:
+			 * add static HTML files with API use examples.
+			 * Note: this logs the value of spark.staticfiles.StaticFilesFolder 
+			 * on warn level for information.
+			 */
 			staticFiles.externalLocation(rest_static_location);
 
 			/* Scripting API mapping */

--- a/core/utils/gaiasky-release.json
+++ b/core/utils/gaiasky-release.json
@@ -24,7 +24,6 @@
 		"core/exe/gaiasky" : {
 		  "commentchar" : "#",
 		  "tocomment" : [
-			  "OPTS=\"$OPTS -Drest-static.location=\\\"$GSDIR/rest-static/\\\"\"",
 			  "OPTS=\"$OPTS -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dorg.slf4j.simpleLogger.showThreadName=false\""
 			]
 		}


### PR DESCRIPTION
With current setup, there is no need anymore to place the static files
anywhere else than other assets directories, which removes the need to
define the corresponding system property.